### PR TITLE
Refactor snphost module to capture snphost ok status(pass/failure) in the summary

### DIFF
--- a/modules/guest-measurement/mkosi.extra/usr/local/lib/systemd/system/calculate-measurement.service
+++ b/modules/guest-measurement/mkosi.extra/usr/local/lib/systemd/system/calculate-measurement.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Calculate guest measurement
 DefaultDependencies=no
-After=network-online.target snphost.service
+After=network-online.target snphost-ok.service
 Wants=network-online.target
-ConditionPathExists=/run/snphost.ok
+ConditionPathExists=/run/snphost-ok.ok
 
 [Service]
 Type=oneshot

--- a/modules/snphost/mkosi.extra/usr/local/lib/systemd/system-preset/10-snphost-ok.preset
+++ b/modules/snphost/mkosi.extra/usr/local/lib/systemd/system-preset/10-snphost-ok.preset
@@ -1,0 +1,1 @@
+enable snphost-ok.service

--- a/modules/snphost/mkosi.extra/usr/local/lib/systemd/system-preset/10-snphost.preset
+++ b/modules/snphost/mkosi.extra/usr/local/lib/systemd/system-preset/10-snphost.preset
@@ -1,1 +1,0 @@
-enable snphost.service

--- a/modules/snphost/mkosi.extra/usr/local/lib/systemd/system/snphost-ok.service
+++ b/modules/snphost/mkosi.extra/usr/local/lib/systemd/system/snphost-ok.service
@@ -1,15 +1,15 @@
 [Unit]
-Description=Run snphost checks to make sure host is correctly set-up for SNP functionalities.
+Description=Run snphost ok to  make sure host is correctly set-up for SNP functionalities.
 DefaultDependencies=no
 After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=snphost ok
 StandardOutput=journal+console
 StandardError=journal+console
-ExecStartPost=/usr/bin/touch /run/snphost.ok
+ExecStartPost=/usr/bin/touch /run/snphost-ok.ok
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR updates the snphost OK service status to update JOB_RESULT json attribute of journalctl json log to "done" or "failed." 

Previously, the journalctl JSON attribute "JOB_RESULT" would always show "done" regardless of whether the snphost test passed or failed.
With this PR, snphost failure is captured in journalctl json log
