### PR TITLE
Feat: Publish development images as assets on code changes

### DIFF
--- a/.github/workflows/build-host.yml
+++ b/.github/workflows/build-host.yml
@@ -16,7 +16,7 @@ jobs:
           - path: images/host-fedora-41
             name: host-fedora-41
           - path: images/host-ubuntu-oracular
-            name: guest-ubuntu-oracular
+            name: host-ubuntu-oracular
           - path: images/host-debian-bookworm
             name: host-debian-bookworm
           - path: images/host-ubuntu-plucky

--- a/.github/workflows/development-images-release.yml
+++ b/.github/workflows/development-images-release.yml
@@ -1,0 +1,62 @@
+name: publish-latest-images
+on:
+  workflow_run:
+    workflows: ["build-host", "build-guest"]
+    types: [completed]
+
+jobs:
+  release-host:
+    if: ${{ github.event.workflow_run.name == 'build-host' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download host artifacts
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          path: dist/host
+
+      - name: Create host release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: development-host
+          name: Development Host Images
+          body: Automated build of host images from main branch.
+          files: dist/host/**/*.efi
+          fail_on_unmatched_files: true
+          append_body: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-guest:
+    if: ${{ github.event.workflow_run.name == 'build-guest' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Download guest artifacts
+        uses: dawidd6/action-download-artifact@v11
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          path: dist/guest
+
+      - name: Create guest release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: development-guest
+          name: Development Guest Images
+          body: Automated build of guest images from main branch.
+          files: dist/guest/**/*.efi
+          fail_on_unmatched_files: true
+          append_body: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Publish images as assets whenever changes are done to the codebase. This will be a development tag, not an official tagged release. Will help us test changes to the certification process.