### PR TITLE
refactor: reduce unecessary telemetry in verify-guest

### DIFF
--- a/modules/launch-snp-guest/mkosi.extra/usr/local/lib/scripts/verify-guest.sh
+++ b/modules/launch-snp-guest/mkosi.extra/usr/local/lib/scripts/verify-guest.sh
@@ -9,7 +9,7 @@ INTERVAL=1
 ELAPSED=0
 
 while [[ $ELAPSED -lt $TIMEOUT ]]; do
-    if journalctl -D ${BOOT_LOG_DIR} | grep -q "boot-successful"; then
+    if journalctl -D "${BOOT_LOG_DIR}" 2>/dev/null | grep -q "boot-successful"; then
         echo "Guest boot successful."
         exit 0
     fi


### PR DESCRIPTION
The journalctl check prints messages every time it looks for the guest boot status. Redirect stderr to /dev/null since we only need to know if the check failed after the timeout has elapsed.

This will remove all of these lines from the certificate:
Sep 25 20:23:41 journalctl[2079]: No journal files were found.
Sep 25 20:23:42 journalctl[2083]: No journal files were found.
Sep 25 20:23:43 journalctl[2086]: No journal files were found.
Sep 25 20:23:44 journalctl[2089]: No journal files were found.
Sep 25 20:23:45 journalctl[2092]: No journal files were found.
Sep 25 20:23:46 journalctl[2095]: No journal files were found.
Sep 25 20:23:47 journalctl[2099]: No journal files were found.
Sep 25 20:23:48 journalctl[2102]: No journal files were found.
Sep 25 20:23:49 journalctl[2105]: No journal files were found.
Sep 25 20:23:50 journalctl[2108]: No journal files were found.
Sep 25 20:23:51 journalctl[2111]: No journal files were found.
Sep 25 20:23:52 journalctl[2114]: No journal files were found.
Sep 25 20:23:53 journalctl[2117]: No journal files were found.
Sep 25 20:23:54 journalctl[2120]: No journal files were found.
Sep 25 20:23:55 journalctl[2123]: No journal files were found.
Sep 25 20:23:56 journalctl[2126]: No journal files were found.
Sep 25 20:23:57 journalctl[2129]: No journal files were found.
Sep 25 20:23:58 journalctl[2132]: No journal files were found