### PR TITLE
chore: add four targets

### DIFF
--- a/modules/common/mkosi.extra/usr/local/lib/systemd/system-preset/targets.preset
+++ b/modules/common/mkosi.extra/usr/local/lib/systemd/system-preset/targets.preset
@@ -1,0 +1,1 @@
+enable stop.target

--- a/modules/common/mkosi.extra/usr/local/lib/systemd/system/boot.target
+++ b/modules/common/mkosi.extra/usr/local/lib/systemd/system/boot.target
@@ -1,0 +1,7 @@
+# Target reached when all boot services are complete
+# Boot services should use: WantedBy=boot.target
+
+[Unit]
+Description=Boot
+After=network-online.target
+Wants=network-online.target

--- a/modules/common/mkosi.extra/usr/local/lib/systemd/system/exec.target
+++ b/modules/common/mkosi.extra/usr/local/lib/systemd/system/exec.target
@@ -1,0 +1,7 @@
+# Target reached when all jobs are complete
+# Job services should use: WantedBy=exec.target
+
+[Unit]
+Description=Exec
+After=boot.target
+Wants=boot.target

--- a/modules/common/mkosi.extra/usr/local/lib/systemd/system/report.target
+++ b/modules/common/mkosi.extra/usr/local/lib/systemd/system/report.target
@@ -1,0 +1,7 @@
+# Target reached when all reporting is complete
+# Reporting services should use: WantedBy=reporting.target
+
+[Unit]
+Description=Report
+After=exec.target
+Wants=exec.target

--- a/modules/common/mkosi.extra/usr/local/lib/systemd/system/stop.target
+++ b/modules/common/mkosi.extra/usr/local/lib/systemd/system/stop.target
@@ -1,0 +1,10 @@
+# Target reached once reporting is complete
+# Final services should use: WantedBy=stop.target
+
+[Unit]
+Description=Stop
+After=report.target
+Wants=report.target
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These targets are, in order:

* boot
* exec
* report
* stop

These provide handy synchronization points for the other services.