### PR TITLE
feat: add reboot service module

### DIFF
--- a/modules/host/mkosi.conf
+++ b/modules/host/mkosi.conf
@@ -9,3 +9,4 @@ Include=../logging/capture-guest-logs-in-host
 Include=../logging/display-guest-logs
 Include=../logging/sev-certificate-generator
 Include=../beacon
+Include=../reboot

--- a/modules/reboot/mkosi.extra/usr/local/lib/scripts/login-or-reboot.sh
+++ b/modules/reboot/mkosi.extra/usr/local/lib/scripts/login-or-reboot.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+TIMEOUT=30
+TTY="tty1"
+
+# Print prompt to tty1
+echo "Tests complete. System will reboot in $TIMEOUT seconds." > /dev/$TTY
+echo "Press any key to cancel reboot and drop into root shell..." > /dev/$TTY
+
+# Wait for keypress on tty1
+if read -t "$TIMEOUT" -n 1 < /dev/$TTY; then
+    echo "Key pressed — reboot cancelled." > /dev/$TTY
+
+    # Stop existing getty so we can take over tty1
+    systemctl stop getty@$TTY.service || true
+
+    # Drop straight into root shell on tty1
+    exec /sbin/agetty --autologin root --noclear $TTY $TERM
+else
+    echo "No key pressed. Rebooting now..." > /dev/$TTY
+    systemctl reboot
+fi

--- a/modules/reboot/mkosi.extra/usr/local/lib/systemd/system-preset/10-login-or-reboot.preset
+++ b/modules/reboot/mkosi.extra/usr/local/lib/systemd/system-preset/10-login-or-reboot.preset
@@ -1,0 +1,1 @@
+enable login-or-reboot.service

--- a/modules/reboot/mkosi.extra/usr/local/lib/systemd/system/login-or-reboot.service
+++ b/modules/reboot/mkosi.extra/usr/local/lib/systemd/system/login-or-reboot.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Prompt user to login or reboot after tests
+After=beacon-report.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/lib/scripts/login-or-reboot.sh
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This service will reboot the system after the tests are finished running. It will wait for 30 seconds after the tests are done, but if user presses a key during the wait, it will automatically log in as root user into the system.